### PR TITLE
remove 'Warning: statement is not reachable' duplicate error messages

### DIFF
--- a/source/inifiled.d
+++ b/source/inifiled.d
@@ -30,7 +30,6 @@ bool isINI(T)() @trusted {
 			return true;
 		}
 	}
-	return false;
 }
 
 bool isINI(T, string mem)() @trusted {
@@ -39,7 +38,6 @@ bool isINI(T, string mem)() @trusted {
 			return true;
 		}
 	}
-	return false;
 }
 
 string getINI(T)() @trusted {


### PR DESCRIPTION
compiling dscanner with latest submodules gives tons of such duplicate warnings.
