### PR TITLE
Import old std.typetuple on older compilers

### DIFF
--- a/source/inifiled.d
+++ b/source/inifiled.d
@@ -25,13 +25,19 @@ struct INI {
 }
 
 template isINI(T) {
-	import std.meta : anySatisfy;
+	static if (__VERSION__ >= 2068)
+		import std.meta : anySatisfy;
+	else
+		import std.typetuple : anySatisfy;
 	enum i(alias U) = is(U == INI);
 	enum isINI = anySatisfy!(i, __traits(getAttributes, T));
 }
 
 template isINI(T, string mem) {
-	import std.meta : anySatisfy;
+	static if (__VERSION__ >= 2068)
+		import std.meta : anySatisfy;
+	else
+		import std.typetuple : anySatisfy;
 	enum i(alias U) = is(U == INI);
 	enum isINI = anySatisfy!(i, __traits(getAttributes, 
 		__traits(getMember, T, mem))


### PR DESCRIPTION
This is needed so that I can use inifiled with ldc 0.16.
