### PR TITLE
Add multiline support

### DIFF
--- a/test/dscanner.ini
+++ b/test/dscanner.ini
@@ -1,4 +1,7 @@
 [inifiled.StaticAnalysisConfig]
 style_check="disabled"
+multi_line= "+std.algorithm \
+-std.foo \
+"
 [inifiled.ModuleFilters]
 style_check = "+std.algorithm"


### PR DESCRIPTION
> Multi-line values can be provided by ending the line with a backslash (\).

see e.g. http://ndevilla.free.fr/iniparser/html/index.html