### PR TITLE
Allow quiet debug builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,5 +6,16 @@
 	"authors": ["Robert burner Schadek"],
 	"license": "LGPL3",
 	"importPaths": ["source"],
-	"sourcePaths": ["source"]
+	"sourcePaths": ["source"],
+	"configurations": [
+		{
+			"name": "library",
+			"targetType": "library",
+			"versions": ["debugLogs"]
+		},
+		{
+			"name": "library-quiet",
+			"targetType": "library"
+		}
+	]
 }

--- a/source/inifiled.d
+++ b/source/inifiled.d
@@ -227,10 +227,10 @@ string readINIFileImpl(T,IRange)(ref T t, ref IRange input, int depth = 0)
 	import std.string : split;
 	import std.algorithm.searching : startsWith;
 	import std.traits : hasUDA, fullyQualifiedName;
-	debug {
+	debug version (debugLogs) {
 		import std.stdio : writefln;
 	}
-	debug {
+	debug version (debugLogs) {
 		writefln("%*s%d %s %x", depth, "", __LINE__, fullyQualifiedName!(typeof(t)),
 			cast(void*)&input);
 	}
@@ -258,7 +258,7 @@ string readINIFileImpl(T,IRange)(ref T t, ref IRange input, int depth = 0)
 		if(line.startsWith(";") || isMultiLine) {
 			continue;
 		}
-		debug {
+		debug version (debugLogs) {
 			writefln("%*s%d %s %s %b", depth, "", __LINE__, line, fullyQualifiedName!T,
 				isSection(line));
 		}
@@ -269,7 +269,7 @@ string readINIFileImpl(T,IRange)(ref T t, ref IRange input, int depth = 0)
 			const name = fullyQualifiedName!T;
 		}
 		if(isSection(line) && getSection(line) != name) {
-			debug {
+			debug version (debugLogs) {
 				pragma(msg, buildSectionParse!(T));
 				writefln("%*s%d %s", depth, "", __LINE__, getSection(line));
 				writefln("%*s%d %x", depth, "", __LINE__,
@@ -278,7 +278,7 @@ string readINIFileImpl(T,IRange)(ref T t, ref IRange input, int depth = 0)
 
 			mixin(buildSectionParse!(T));
 		} else if(isKeyValue(line)) {
-			debug {
+			debug version (debugLogs) {
 				pragma(msg, buildValueParse!(T));
 				writefln("%*s%d %s %s", depth, "", __LINE__, getKey(line),
 					getValue(line));


### PR DESCRIPTION
When using `readINIFile` in a debug build, some debug logs are used. However this pollutes stdout and is not very practical when the program makes use of stdout itself...
This PR adds a `library-quiet` configuration that doesn't output anything, even in debug builds. The default `library` configuration still does however, so it shouldn't break anything.